### PR TITLE
add support for creating a profile named "default"

### DIFF
--- a/aws_role_credentials/models.py
+++ b/aws_role_credentials/models.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import xml.etree.ElementTree as ET
-import ConfigParser
 import base64
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser  # ver. < 3.0
 
 
 class SamlAssertion:
@@ -48,8 +52,12 @@ class AwsCredentialsFile:
         return
 
     def _add_profile(self, name, profile):
-        config = ConfigParser.RawConfigParser()
-        config.read(self.filename)
+
+        config = configparser.ConfigParser(interpolation=None)
+        try:
+            config.read_file(open(self.filename, 'r'))
+        except:
+            pass
 
         if not config.has_section(name):
             config.add_section(name)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ watchdog==0.8.3
 flake8==2.4.1
 mock==1.3.0
 tox==2.1.1
+configparser==3.5.0b2
 coverage==4.0
 Sphinx==1.3.1
 pyfakefs==2.7

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -15,6 +15,7 @@ from tests.helper import saml_assertion, read_config_file, Struct
 from aws_role_credentials import cli
 from StringIO import StringIO
 
+
 class TestAcceptance(fake_filesystem_unittest.TestCase):
     HOME = expanduser('~/')
     TEST_FILE = os.path.join(HOME, '.aws/credentials')

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -13,6 +13,7 @@ from pyfakefs import fake_filesystem_unittest
 from tests.helper import saml_assertion, read_config_file, Struct
 from aws_role_credentials.actions import Actions
 
+
 class TestActions(unittest.TestCase):
     @mock.patch('aws_role_credentials.actions.boto.sts')
     def test_credentials_are_generated_from_saml(self, mock_sts):


### PR DESCRIPTION
* switch to using backports configparser for Python < 3,
which allows one to create a profile (config section) named "default"
* few flake8 fixes
* tests pass