### PR TITLE
Bunch of fixes to be more python 3 compatible.

### DIFF
--- a/aws_role_credentials/actions.py
+++ b/aws_role_credentials/actions.py
@@ -24,12 +24,12 @@ class Actions:
 
     @staticmethod
     def print_credentials(credentials_filename, profile, credentials):
-        print '\n\n----------------------------------------------------------------'
-        print 'Your credentials have been stored in the AWS configuration file {0} under the {1} profile.'.format(credentials_filename, profile)
-        print 'Note that they will expire at {0}.'.format(credentials.expiration)
-        print 'You may safely rerun this script at any time to refresh your credentials.'
-        print 'To use this credential, call the AWS CLI with the --profile option (e.g. aws --profile {0} ec2 describe-instances).'.format(profile)
-        print '----------------------------------------------------------------\n\n'
+        print('\n\n----------------------------------------------------------------')
+        print('Your credentials have been stored in the AWS configuration file {0} under the {1} profile.'.format(credentials_filename, profile))
+        print('Note that they will expire at {0}.'.format(credentials.expiration))
+        print('You may safely rerun this script at any time to refresh your credentials.')
+        print('To use this credential, call the AWS CLI with the --profile option (e.g. aws --profile {0} ec2 describe-instances).'.format(profile))
+        print('----------------------------------------------------------------\n\n')
 
     @staticmethod
     def persist_credentials(credentials_filename,

--- a/aws_role_credentials/models.py
+++ b/aws_role_credentials/models.py
@@ -65,9 +65,10 @@ class AwsCredentialsFile:
             config.write(configfile)
 
     def add_profile(self, name, region, credentials):
-        self._add_profile(name, {'output': 'json',
-                                 'region': region,
-                                 'aws_access_key_id': credentials.access_key,
-                                 'aws_secret_access_key': credentials.secret_key,
-                                 'aws_security_token': credentials.session_token,
-                                 'aws_session_token': credentials.session_token})
+        name = unicode(name)
+        self._add_profile(name, {u'output': u'json',
+                                 u'region': unicode(region),
+                                 u'aws_access_key_id': unicode(credentials.access_key),
+                                 u'aws_secret_access_key': unicode(credentials.secret_key),
+                                 u'aws_security_token': unicode(credentials.session_token),
+                                 u'aws_session_token': unicode(credentials.session_token)})

--- a/aws_role_credentials/models.py
+++ b/aws_role_credentials/models.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import xml.etree.ElementTree as ET
 import base64
+import xml.etree.ElementTree as ET
 
-try:
-    import configparser
-except ImportError:
-    import ConfigParser  # ver. < 3.0
+from six.moves import configparser
 
 
 class SamlAssertion:
@@ -42,7 +39,7 @@ class SamlAssertion:
                 in roles_values[0]]
 
     def encode(self):
-        return base64.b64encode(self.assertion)
+        return base64.b64encode(self.assertion.encode('utf8'))
 
 
 class AwsCredentialsFile:
@@ -63,7 +60,7 @@ class AwsCredentialsFile:
             config.add_section(name)
 
         [(config.set(name, k, v))
-         for k, v in profile.iteritems()]
+         for k, v in profile.items()]
 
         with open(self.filename, 'w+') as configfile:
             config.write(configfile)

--- a/aws_role_credentials/models.py
+++ b/aws_role_credentials/models.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import base64
+import configparser
 import xml.etree.ElementTree as ET
-
-from six.moves import configparser
 
 
 class SamlAssertion:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'boto',
-    'configparser'
+    'six',
 ]
 
 # as of Python >= 2.7 and >= 3.2, the argparse module is maintained within
@@ -34,6 +34,8 @@ if sys.version_info < (2, 7) or (3, 0) <= sys.version_info < (3, 3):
 
 
 test_requirements = [
+    'mock',
+    'pyfakefs',
     'unittest2'
 ]
 
@@ -60,7 +62,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ requirements = [
     'six',
 ]
 
+if sys.version_info < (3, 0):
+    requirements.append('configparser')
+
 # as of Python >= 2.7 and >= 3.2, the argparse module is maintained within
 # the Python standard library, otherwise we install it as a separate package
 if sys.version_info < (2, 7) or (3, 0) <= sys.version_info < (3, 3):

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -8,12 +8,13 @@ else:
     import unittest
 
 from pyfakefs import fake_filesystem_unittest
+import six
 
 from os.path import expanduser
 from mock import MagicMock
 from tests.helper import saml_assertion, read_config_file, Struct
 from aws_role_credentials import cli
-from StringIO import StringIO
+from six.moves import StringIO
 
 
 class TestAcceptance(fake_filesystem_unittest.TestCase):
@@ -47,15 +48,16 @@ class TestAcceptance(fake_filesystem_unittest.TestCase):
                   '--profile', 'test-profile',
                   '--region', 'un-south-1'])
 
-        self.assertItemsEqual(read_config_file(self.TEST_FILE),
-                              ['[test-profile]',
-                               'output = json',
-                               'region = un-south-1',
-                               'aws_access_key_id = SAML_ACCESS_KEY',
-                               'aws_secret_access_key = SAML_SECRET_KEY',
-                               'aws_security_token = SAML_TOKEN',
-                               'aws_session_token = SAML_TOKEN',
-                               ''])
+        six.assertCountEqual(self,
+                             read_config_file(self.TEST_FILE),
+                             ['[test-profile]',
+                              'output = json',
+                              'region = un-south-1',
+                              'aws_access_key_id = SAML_ACCESS_KEY',
+                              'aws_secret_access_key = SAML_SECRET_KEY',
+                              'aws_security_token = SAML_TOKEN',
+                              'aws_session_token = SAML_TOKEN',
+                              ''])
 
     @mock.patch('aws_role_credentials.actions.boto.sts')
     def test_credentials_are_generated_from_user(self, mock_sts):
@@ -74,15 +76,15 @@ class TestAcceptance(fake_filesystem_unittest.TestCase):
                   '--profile', 'test-profile',
                   '--region', 'un-south-1'])
 
-        self.assertItemsEqual(read_config_file(self.TEST_FILE),
-                              ['[test-profile]',
-                               'output = json',
-                               'region = un-south-1',
-                               'aws_access_key_id = SAML_ACCESS_KEY',
-                               'aws_secret_access_key = SAML_SECRET_KEY',
-                               'aws_security_token = SAML_TOKEN',
-                               'aws_session_token = SAML_TOKEN',
-                               ''])
+        six.assertCountEqual(self, read_config_file(self.TEST_FILE),
+                             ['[test-profile]',
+                              'output = json',
+                              'region = un-south-1',
+                              'aws_access_key_id = SAML_ACCESS_KEY',
+                              'aws_secret_access_key = SAML_SECRET_KEY',
+                              'aws_security_token = SAML_TOKEN',
+                              'aws_session_token = SAML_TOKEN',
+                              ''])
 
     @mock.patch('aws_role_credentials.actions.Popen')
     @mock.patch('aws_role_credentials.actions.boto.sts')

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -9,6 +9,7 @@ else:
     import unittest
 
 from pyfakefs import fake_filesystem_unittest
+import six
 
 from tests.helper import saml_assertion, read_config_file, Struct
 from aws_role_credentials.actions import Actions
@@ -111,12 +112,12 @@ class TestConfigActions(fake_filesystem_unittest.TestCase):
                                     'test-profile',
                                     'un-south-1', token, True)
 
-        self.assertItemsEqual(read_config_file(self.TEST_FILE),
-                              ['[test-profile]',
-                               'output = json',
-                               'region = un-south-1',
-                               'aws_access_key_id = SAML_ACCESS_KEY',
-                               'aws_secret_access_key = SAML_SECRET_KEY',
-                               'aws_security_token = SAML_TOKEN',
-                               'aws_session_token = SAML_TOKEN',
-                               ''])
+        six.assertCountEqual(self, read_config_file(self.TEST_FILE),
+                             ['[test-profile]',
+                              'output = json',
+                              'region = un-south-1',
+                              'aws_access_key_id = SAML_ACCESS_KEY',
+                              'aws_secret_access_key = SAML_SECRET_KEY',
+                              'aws_security_token = SAML_TOKEN',
+                              'aws_session_token = SAML_TOKEN',
+                              ''])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@ else:
     import unittest
 
 from pyfakefs import fake_filesystem_unittest
+import six
 
 from tests.helper import saml_assertion, write_config_file, read_config_file, Struct
 from aws_role_credentials.models import SamlAssertion, AwsCredentialsFile
@@ -49,7 +50,7 @@ class TestSamlAssertion(unittest.TestCase):
                                                      'principle': 'arn:aws:iam::2222:saml-provider/IDP'}]
 
     def test_assertion_is_encoded(self):
-        assert SamlAssertion("test encoding").encode() == 'dGVzdCBlbmNvZGluZw=='
+        assert SamlAssertion("test encoding").encode() == b'dGVzdCBlbmNvZGluZw=='
 
 
 class TestAwsCredentialsFile(fake_filesystem_unittest.TestCase):
@@ -69,15 +70,15 @@ class TestAwsCredentialsFile(fake_filesystem_unittest.TestCase):
                                         'session_token': 'SESSION_TOKEN',
                                         'expiration': 'TEST_EXPIRATION'}))
 
-        self.assertItemsEqual(read_config_file(self.TEST_FILE),
-                              ['[dev]',
-                               'output = json',
-                               'region = un-west-5',
-                               'aws_access_key_id = ACCESS_KEY',
-                               'aws_secret_access_key = SECRET_KEY',
-                               'aws_security_token = SESSION_TOKEN',
-                               'aws_session_token = SESSION_TOKEN',
-                               ''])
+        six.assertCountEqual(self, read_config_file(self.TEST_FILE),
+                             ['[dev]',
+                              'output = json',
+                              'region = un-west-5',
+                              'aws_access_key_id = ACCESS_KEY',
+                              'aws_secret_access_key = SECRET_KEY',
+                              'aws_security_token = SESSION_TOKEN',
+                              'aws_session_token = SESSION_TOKEN',
+                              ''])
 
     def test_profile_is_updated(self):
         write_config_file(self.TEST_FILE,
@@ -94,15 +95,15 @@ class TestAwsCredentialsFile(fake_filesystem_unittest.TestCase):
                                         'session_token': 'SESSION_TOKEN',
                                         'expiration': 'TEST_EXPIRATION'}))
 
-        self.assertItemsEqual(read_config_file(self.TEST_FILE),
-                              ['[dev]',
-                               'region = un-west-5',
-                               'aws_access_key_id = ACCESS_KEY',
-                               'aws_secret_access_key = SECRET_KEY',
-                               'output = json',
-                               'aws_security_token = SESSION_TOKEN',
-                               'aws_session_token = SESSION_TOKEN',
-                               ''])
+        six.assertCountEqual(self, read_config_file(self.TEST_FILE),
+                             ['[dev]',
+                              'region = un-west-5',
+                              'aws_access_key_id = ACCESS_KEY',
+                              'aws_secret_access_key = SECRET_KEY',
+                              'output = json',
+                              'aws_security_token = SESSION_TOKEN',
+                              'aws_session_token = SESSION_TOKEN',
+                              ''])
 
     def test_existing_profiles_are_preserved(self):
         write_config_file(self.TEST_FILE,
@@ -121,23 +122,23 @@ class TestAwsCredentialsFile(fake_filesystem_unittest.TestCase):
                                         'session_token': 'SESSION_TOKEN',
                                         'expiration': 'TEST_EXPIRATION'}))
 
-        self.assertItemsEqual(read_config_file(self.TEST_FILE),
-                              ['[test]',
-                               'region = us-west-2',
-                               'aws_access_key_id = TEST_KEY',
-                               'aws_secret_access_key = TEST_ACCESS',
-                               'output = none',
-                               'aws_security_token = TEST_TOKEN',
-                               'aws_session_token = TEST_TOKEN',
-                               '',
-                               '[dev]',
-                               'output = json',
-                               'region = un-west-5',
-                               'aws_access_key_id = ACCESS_KEY',
-                               'aws_secret_access_key = SECRET_KEY',
-                               'aws_security_token = SESSION_TOKEN',
-                               'aws_session_token = SESSION_TOKEN',
-                               ''])
+        six.assertCountEqual(self, read_config_file(self.TEST_FILE),
+                             ['[test]',
+                              'region = us-west-2',
+                              'aws_access_key_id = TEST_KEY',
+                              'aws_secret_access_key = TEST_ACCESS',
+                              'output = none',
+                              'aws_security_token = TEST_TOKEN',
+                              'aws_session_token = TEST_TOKEN',
+                              '',
+                              '[dev]',
+                              'output = json',
+                              'region = un-west-5',
+                              'aws_access_key_id = ACCESS_KEY',
+                              'aws_secret_access_key = SECRET_KEY',
+                              'aws_security_token = SESSION_TOKEN',
+                              'aws_session_token = SESSION_TOKEN',
+                              ''])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Handles the obvious things that prevent the test suite from running.  print statements, renamed/moved modules & functions, missing dependencies, unicode stuff, etc.

There is still some funny business in a couple tests that should be investigated:

test_user_subcommand_requires_positional_args (tests.test_cli.TestArgParsing) ... usage: test user [-h] [-V] [--profile PROFILE] [--region REGION]
                 [--exec EXEC_COMMAND] [-q]
                 [--mfa-serial-number MFA_SERIAL_NUMBER]
                 [--mfa-token MFA_TOKEN]
                 role_arn session_name
test user: error: the following arguments are required: role_arn, session_name
ok
test_user_subcommand_requires_session_name (tests.test_cli.TestArgParsing) ... usage: test user [-h] [-V] [--profile PROFILE] [--region REGION]
                 [--exec EXEC_COMMAND] [-q]
                 [--mfa-serial-number MFA_SERIAL_NUMBER]
                 [--mfa-token MFA_TOKEN]
                 role_arn session_name
test user: error: the following arguments are required: session_name
ok