### PR TITLE
add a --role-arn argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,12 @@ Simply pipe a SAML assertion into awssaml
     # create credentials from saml assertion
     $ oktaauth -u jobloggs | aws_role_credentials saml --profile dev
 
+Or for assuming a known role name:
+
+.. code-block:: shell
+
+    # create credentials from saml assertion using a known role ARN
+    $ oktaauth -u jobloggs | aws_role_credentials saml --profile dev --role-arn arn:aws:iam::098765432109:role/ReadOnly
 
 Or for assuming a role using an IAM user:
 
@@ -64,7 +70,10 @@ Options
 
     --profile          Use a specific profile in your credential file (e.g. Development).  Defaults to sts.
     --region           The region to use. Overrides config/env settings.  Defaults to us-east-1.
+    --role-arn         Optional `role ARN`_ to use when multiple roles are available.
     --exec             The command to execute with the AWS credentials
+
+.. _role ARN: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
 
 Thanks
 ======

--- a/aws_role_credentials/actions.py
+++ b/aws_role_credentials/actions.py
@@ -75,7 +75,12 @@ class Actions:
     def saml_token(region, assertion, **kwargs):
         assertion = SamlAssertion(assertion)
         roles = assertion.roles()
-        if len(roles) > 1:
+        if kwargs.get('role_arn', False):
+            for i, role in enumerate(roles):
+                if role['role'] == kwargs['role_arn']:
+                    role = roles[i]
+                    break
+        elif len(roles) > 1:
             print('Please select the role you would like to assume:')
             for i, role in enumerate(roles):
                 print('[{}] - {}'.format(i, role['role']))

--- a/aws_role_credentials/cli.py
+++ b/aws_role_credentials/cli.py
@@ -74,6 +74,10 @@ def create_parser(prog, epilog,
         help='The region to use. Overrides config/env settings.')
 
     parent_parser.add_argument(
+        '--role-arn', type=str,
+        help='Optional role ARN to use when multiple roles are available.')
+
+    parent_parser.add_argument(
         '--exec', type=str,
         dest='exec_command',
         help='If present then the string is read as a command to execute with the AWS credentials set as environment variables.')


### PR DESCRIPTION
This will give the user the ability to pass in the ARN of the role
he/she is attempting to assume the credentials for.  This is useful if
the user has access to multiple roles he/she can assume, and saves them
from being prompted to select one from a list.